### PR TITLE
Single diagnostics are duplicated when there are multiple producers

### DIFF
--- a/lua/lsp-virtual-improved/init.lua
+++ b/lua/lsp-virtual-improved/init.lua
@@ -44,7 +44,7 @@ function M.setup()
           vim.api.nvim_create_autocmd({ 'CursorHold', 'DiagnosticChanged' }, {
             buffer = bufnr,
             callback = function()
-              render.filter_current_line(namespace, bufnr, vim.diagnostic.get(bufnr), opts)
+              render.filter_current_line(namespace, bufnr, vim.diagnostic.get(bufnr, { namespace = namespace }), opts)
             end,
           })
           render.filter_current_line(namespace, bufnr, diagnostics, opts)


### PR DESCRIPTION
Hi 👋 

Thanks for the great project!

I'm trying to use this project to show diagnostics for all lines except the current one (I'm using lsp_lines.nvim for the current).

I'm finding that when I've got multiple diagnostic producers they both render the same diagnostic despite it only being produced by one of them.

The below image illustrates the issue. I've got `tsserver` and `eslint` language servers attached. On line 21 `tsserver` is reporting the diagnostic but lsp-virtual-improved is rendering it for both providers. On line 23 both providers have diagnostics but both are rendering the diagnostic from `tsserver`.
<img width="1820" alt="Screenshot 2024-01-16 at 22 28 45" src="https://github.com/luozhiya/lsp-virtual-improved.nvim/assets/991180/229cdb37-360e-4b3d-ad51-ad4525ee1147">

This is similar to the config I'm using
```lua
require('lsp-virtual-improved').setup()

vim.diagnostic.config {
  virtual_text = false,
  virtual_improved = {
    current_line = 'hide',
  },
}
```

I _think_ this PR should fix this by ensuring the diagnostics used by the autocmd are scoped to the producer's namespace. Let me know what you think!