### PR TITLE
Prevent adding extmarks to unloaded buffers

### DIFF
--- a/lua/lsp-virtual-improved/render.lua
+++ b/lua/lsp-virtual-improved/render.lua
@@ -180,6 +180,10 @@ function M.show(namespace, bufnr, diagnostics, opts)
     opts = { opts, 't', true },
   })
 
+  if not vim.api.nvim_buf_is_loaded(bufnr) then
+    return
+  end
+
   local ns = vim.diagnostic.get_namespace(namespace)
   local virt_improved_ns = ns.user_data.virt_improved_ns
   vim.api.nvim_buf_clear_namespace(bufnr, virt_improved_ns, 0, -1)


### PR DESCRIPTION
Hi again 👋 

I've found a small issue when closing a buffer with diagnostics but another buffer has unsaved changes I get an `Invalid 'line': out of range` error

```
Error detected while processing DiagnosticChanged Autocommands for "<buffer=6>":
Error executing lua callback: ...irtual-improved.nvim/lua/lsp-virtual-improved/render.lua:223: Invalid 'line': out of range
stack traceback:
        [C]: in function 'nvim_buf_set_extmark'
        ...irtual-improved.nvim/lua/lsp-virtual-improved/render.lua:223: in function 'show'
        ...irtual-improved.nvim/lua/lsp-virtual-improved/render.lua:164: in function 'filter_current_line'
        ...-virtual-improved.nvim/lua/lsp-virtual-improved/init.lua:47: in function <...-virtual-improved.nvim/lua/lsp-virtual-improved/init.lua:46>
        [C]: in function 'nvim_exec_autocmds'
        ...nwrapped-0.9.5/share/nvim/runtime/lua/vim/diagnostic.lua:706: in function 'set'
        ...pped-0.9.5/share/nvim/runtime/lua/vim/lsp/diagnostic.lua:236: in function 'handler'
        ...eovim-unwrapped-0.9.5/share/nvim/runtime/lua/vim/lsp.lua:1056: in function ''
        vim/_editor.lua: in function <vim/_editor.lua:0>
```

<img width="1820" alt="Screenshot 2024-01-17 at 10 10 32" src="https://github.com/luozhiya/lsp-virtual-improved.nvim/assets/991180/fe9c4f94-53ce-4f72-aa80-101fc1eac4ac">

A [similar issue](https://lists.sr.ht/~whynothugo/lsp_lines.nvim/patches/45776) looks to have been raised again lsp_lines.nvim so I've applied the same fix

### Steps to reproduce
1. Open file and make changes (do not save)
2. Open second file and make diagnostic error
3. Close second file `:q!`

**Expected**: second file closes and first file opens
**Actual**: second file closes and first file opens and error shown


