### PR TITLE
fix: Stop adding extmark to line out of buf range

### DIFF
--- a/lua/lsp-virtual-improved/render.lua
+++ b/lua/lsp-virtual-improved/render.lua
@@ -210,12 +210,13 @@ function M.show(namespace, bufnr, diagnostics, opts)
   end
 
   local buffer_line_diagnostics = diagnostic_lines(diagnostics)
+  local buf_line_count = vim.api.nvim_buf_line_count(bufnr)
   for line, line_diagnostics in pairs(buffer_line_diagnostics) do
     if severity then
       line_diagnostics = filter_by_severity(severity, line_diagnostics)
     end
     local virt_texts = get_virt_text_chunks(line_diagnostics, opts.virtual_improved)
-    if virt_texts then
+    if virt_texts and line <= buf_line_count then
       vim.api.nvim_buf_set_extmark(bufnr, virt_improved_ns, line, 0, {
         hl_mode = 'combine',
         virt_text = virt_texts,

--- a/lua/lsp-virtual-improved/render.lua
+++ b/lua/lsp-virtual-improved/render.lua
@@ -216,7 +216,7 @@ function M.show(namespace, bufnr, diagnostics, opts)
       line_diagnostics = filter_by_severity(severity, line_diagnostics)
     end
     local virt_texts = get_virt_text_chunks(line_diagnostics, opts.virtual_improved)
-    if virt_texts and line <= buf_line_count then
+    if virt_texts and line < buf_line_count then
       vim.api.nvim_buf_set_extmark(bufnr, virt_improved_ns, line, 0, {
         hl_mode = 'combine',
         virt_text = virt_texts,


### PR DESCRIPTION
Hi again 👋 

It seems the autocommand can get in a position where it is attempting to apply a diagnostic to a line that has changed number, i.e. lines before it have been deleted.

In this instance you see an error similar to that in #3 
```
Error detected while processing DiagnosticChanged Autocommands for "<buffer=6>":
Error executing lua callback: ...irtual-improved.nvim/lua/lsp-virtual-improved/render.lua:223: Invalid 'line': out of range
stack traceback:
        [C]: in function 'nvim_buf_set_extmark'
        ...irtual-improved.nvim/lua/lsp-virtual-improved/render.lua:223: in function 'show'
        ...irtual-improved.nvim/lua/lsp-virtual-improved/render.lua:164: in function 'filter_current_line'
        ...-virtual-improved.nvim/lua/lsp-virtual-improved/init.lua:47: in function <...-virtual-improved.nvim/lua/lsp-virtual-improved/init.lua:46>
        [C]: in function 'nvim_exec_autocmds'
        ...nwrapped-0.9.5/share/nvim/runtime/lua/vim/diagnostic.lua:706: in function 'set'
        ...pped-0.9.5/share/nvim/runtime/lua/vim/lsp/diagnostic.lua:236: in function 'handler'
        ...eovim-unwrapped-0.9.5/share/nvim/runtime/lua/vim/lsp.lua:1056: in function ''
        vim/_editor.lua: in function <vim/_editor.lua:0>
```

### Steps to reproduce

Requires
```lua
vim.diagnostic.config {
  virtual_improved = {
    current_line = 'hide',
  },
}
```

1. Open file
2. Cause diagnostic against latter line
3. Delete a number of lines before the diagnostic error such that the line with the diagnostic would be beyond the end of the buffer

**Expected**: Diagnostic moves to new line
**Actual**: Above error thrown before diagnostic moved